### PR TITLE
Fixes:

### DIFF
--- a/remodeler/interpretations.ts
+++ b/remodeler/interpretations.ts
@@ -53,9 +53,12 @@ const specialCharacterMapping: { [character: string]: string } = {
 };
 
 export function getValidEnumValueName(originalString: string): string {
-  return !originalString.match(/[A-Za-z0-9]/g) ?
-    getPascalIdentifier(originalString.split('').map(x => specialCharacterMapping[x]).join(' '))
-    : originalString;
+  if (typeof originalString === 'string') {
+    return !originalString.match(/[A-Za-z0-9]/g) ?
+      getPascalIdentifier(originalString.split('').map(x => specialCharacterMapping[x]).join(' '))
+      : originalString;
+  }
+  return originalString;
 }
 
 export function getName(defaultValue: string, original: OpenAPI.Extensions) {

--- a/remodeler/remodeler.ts
+++ b/remodeler/remodeler.ts
@@ -349,6 +349,7 @@ export class Remodeler {
 
   private refOrAdd<TSource, TDestination>(nameIfInline: string, ref: Dereferenced<TSource>, dictionary: Dictionary<TDestination>, copyFunc: (name: string, source: TSource, destinationDictionary: Dictionary<TDestination>) => TDestination): TDestination {
     if (!ref.name) {
+      nameIfInline = (<any>ref).title || (<any>ref)['x-ms-client-name'] || nameIfInline;
       // inline definition - extract it out
       return this.add(nameIfInline, ref, dictionary, copyFunc);
     }


### PR DESCRIPTION
- non-string enum crash (#7)
- missing parent model inlines when it's recursive. https://github.com/Azure/autorest.powershell/issues/517 
- fallback to title or x-ms-client-name instead of using weird name for things.