### PR TITLE
Fix for parameterized host parameter not picking up required

### DIFF
--- a/remodeler/remodeler.ts
+++ b/remodeler/remodeler.ts
@@ -450,8 +450,10 @@ export class Remodeler {
         newOperation.parameters.push(new HttpOperationParameter(parameterName, ParameterLocation.Uri, ImplementationLocation.Method, {
           schema: new Schema(`host${parameterName}`, { type: JsonType.String, description: 'Host parameter type' }),
           description: value.description,
+          required: !!(<any>value)['x-required'],
           details: {
             default: {
+              description: value.description,
               serverParameter: value
             }
           }


### PR DESCRIPTION
- pull required from x-required, 
- pull description too

REQUIRES update to autorest-beta AND autorest-core: 

### make sure you have autorest-beta v3.0.6149 or greater
> `npm install -g @autorest/autorest`  

### make sure you have autorest-core v3.0.6180 or greater (this is a prerelease version, it won't upgrade without running this command)
> `autorest-beta --version:3.0.6180`

